### PR TITLE
Add `-native` commands to `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,13 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 APP_NAME:="triangler_fastapi"
 
 .PHONY:
-	run-develop run-prod
+	run-develop run-develop-native run-shell run-prod
 
 run-develop:
 	docker build --target develop -t ${APP_NAME} . && docker run -it --rm --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} -p 8000:8000 ${APP_NAME}
+
+run-develop-native:
+	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && uvicorn --reload 'triangler_fastapi.main:app'"
 
 run-shell:
 	docker build --target develop -t ${APP_NAME} . && docker run --rm -it --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} --entrypoint bash -p 8000:8000 ${APP_NAME}

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,16 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 APP_NAME:="triangler_fastapi"
 
 .PHONY:
-	run-develop run-develop-native run-shell run-prod
+	run-develop run-develop-native run-tests-native run-shell run-prod
 
 run-develop:
 	docker build --target develop -t ${APP_NAME} . && docker run -it --rm --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} -p 8000:8000 ${APP_NAME}
 
 run-develop-native:
 	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && uvicorn --reload 'triangler_fastapi.main:app'"
+
+run-tests-native:
+	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && pytest -vvv"
 
 run-shell:
 	docker build --target develop -t ${APP_NAME} . && docker run --rm -it --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} --entrypoint bash -p 8000:8000 ${APP_NAME}


### PR DESCRIPTION
This PR adds two new commands to the `Makefile`, these commands are `run-develop-native` and `run-tests-native`. These commands use the locally managed rye virtual environment to spin up the python application. 

The  `run-develop-native` command spins up an instance of the application running under native uvicorn for developing locally. 

The `run-tests-native` command spins up an instance of the test suite.