### PR TITLE
Add a new `run-tests-native` command to `Makefile`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ default_language_version:
   python: "3.12"
 repos:
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.345
+    rev: v1.1.377
     hooks:
     - id: pyright
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
         stages: ["commit"]
@@ -18,12 +18,12 @@ repos:
         stages: ["commit"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.38.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint-fix
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.3.4"
+    rev: "v0.6.1"
     hooks:
       - id: ruff
         args: ["--fix", "--exit-non-zero-on-fix"]

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,19 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 APP_NAME:="triangler_fastapi"
 
 .PHONY:
-	run-develop run-develop-native run-shell run-prod
+	run-develop run-develop-native run-tests-native run-tests-native-loop run-shell run-prod
 
 run-develop:
 	docker build --target develop -t ${APP_NAME} . && docker run -it --rm --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} -p 8000:8000 ${APP_NAME}
 
 run-develop-native:
 	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && uvicorn --reload 'triangler_fastapi.main:app'"
+
+run-tests-native:
+	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && pytest -vvv"
+
+run-tests-native-loop:
+	zsh -c ". .venv/bin/activate && set -a && . ./dev.env && set +a && cd src && ptw . -vvv --now --patterns '*.py,pyproject.toml' --delay 0.5 --clear --color=yes"
 
 run-shell:
 	docker build --target develop -t ${APP_NAME} . && docker run --rm -it --env-file ./dev.env -v ${ROOT_DIR}/src/${APP_NAME}:/app/src/${APP_NAME} --entrypoint bash -p 8000:8000 ${APP_NAME}


### PR DESCRIPTION
Prior to this change, there was only an option for running this application as a docker container. This is the intended way to run the application however it meant there was a dev time dependancy on having docker installed and enough spare ram to spin up a virtual machine when developing on Macos and Windows.

This change adds the `run-tests-native` command which uses the locally managed rye virtual environment to spin up the application and run the tests natively. This means that there is no longer a dependency for docker when developing locally.