### PR TITLE
Update github actions to use `phi-friday/install-rye@v2`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: phi-friday/install-rye@v1.4
+    - uses: phi-friday/install-rye@v2
       id: install-rye
       with:
         rye_version: "latest" # optional

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: phi-friday/install-rye@v1.4
+    - uses: phi-friday/install-rye@v2
       id: install-rye
       with:
         rye_version: "latest" # optional

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -19,7 +19,7 @@ anyio==4.4.0
 certifi==2024.7.4
     # via httpcore
     # via httpx
-cffi==1.16.0
+cffi==1.17.0
     # via cryptography
 cfgv==3.4.0
     # via pre-commit
@@ -37,7 +37,7 @@ ecdsa==0.19.0
     # via python-jose
 execnet==2.1.1
     # via pytest-xdist
-fastapi==0.112.0
+fastapi==0.112.1
 filelock==3.15.4
     # via virtualenv
 h11==0.14.0
@@ -65,7 +65,7 @@ markupsafe==2.1.5
     # via mako
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.0.1
+numpy==2.1.0
     # via scipy
 packaging==24.1
     # via pytest
@@ -102,24 +102,24 @@ python-dotenv==1.0.1
 python-jose==3.3.0
 python-multipart==0.0.9
     # via starlette-admin
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via pre-commit
     # via uvicorn
 qrcode==7.4.2
 rsa==4.9
     # via python-jose
-ruff==0.5.6
-scipy==1.14.0
+ruff==0.6.1
+scipy==1.14.1
 six==1.16.0
     # via ecdsa
 sniffio==1.3.1
     # via anyio
     # via httpx
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via alembic
     # via pytest-alembic
     # via pytest-mock-resources
-starlette==0.37.2
+starlette==0.38.2
     # via fastapi
     # via starlette-admin
 starlette-admin==0.14.1
@@ -131,16 +131,16 @@ typing-extensions==4.12.2
     # via pytest-mock-resources
     # via qrcode
     # via sqlalchemy
-uvicorn==0.30.5
-uvloop==0.19.0
+uvicorn==0.30.6
+uvloop==0.20.0
     # via uvicorn
 virtualenv==20.26.3
     # via pre-commit
-watchdog==4.0.1
+watchdog==4.0.2
     # via pytest-watch
     # via pytest-watcher
-watchfiles==0.22.0
+watchfiles==0.23.0
     # via uvicorn
-websockets==12.0
+websockets==13.0
     # via uvicorn
-wheel==0.43.0
+wheel==0.44.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -14,7 +14,7 @@ annotated-types==0.7.0
 anyio==4.4.0
     # via starlette
     # via watchfiles
-cffi==1.16.0
+cffi==1.17.0
     # via cryptography
 click==8.1.7
     # via uvicorn
@@ -22,7 +22,7 @@ cryptography==43.0.0
     # via python-jose
 ecdsa==0.19.0
     # via python-jose
-fastapi==0.112.0
+fastapi==0.112.1
 h11==0.14.0
     # via uvicorn
 httptools==0.6.1
@@ -37,7 +37,7 @@ mako==1.3.5
 markupsafe==2.1.5
     # via jinja2
     # via mako
-numpy==2.0.1
+numpy==2.1.0
     # via scipy
 pillow==10.4.0
     # via qrcode
@@ -57,19 +57,19 @@ python-dotenv==1.0.1
 python-jose==3.3.0
 python-multipart==0.0.9
     # via starlette-admin
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via uvicorn
 qrcode==7.4.2
 rsa==4.9
     # via python-jose
-scipy==1.14.0
+scipy==1.14.1
 six==1.16.0
     # via ecdsa
 sniffio==1.3.1
     # via anyio
-sqlalchemy==2.0.31
+sqlalchemy==2.0.32
     # via alembic
-starlette==0.37.2
+starlette==0.38.2
     # via fastapi
     # via starlette-admin
 starlette-admin==0.14.1
@@ -80,11 +80,11 @@ typing-extensions==4.12.2
     # via pydantic-core
     # via qrcode
     # via sqlalchemy
-uvicorn==0.30.5
-uvloop==0.19.0
+uvicorn==0.30.6
+uvloop==0.20.0
     # via uvicorn
-watchfiles==0.22.0
+watchfiles==0.23.0
     # via uvicorn
-websockets==12.0
+websockets==13.0
     # via uvicorn
-wheel==0.43.0
+wheel==0.44.0

--- a/src/tests/api/client.py
+++ b/src/tests/api/client.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from triangler_fastapi.main import app
 
 


### PR DESCRIPTION
Prior to this change, the CI actions were using `phi-friday/install-rye@v1.4`.

This change updates the CI actions to use: `phi-friday/install-rye@v2`