### PR TITLE
Improve testing for experiment API endpoints

### DIFF
--- a/src/tests/api/test_experiments.py
+++ b/src/tests/api/test_experiments.py
@@ -36,6 +36,17 @@ class TestExperimentsApiEndpoints:
         assert test_experiment.name == experiment.name
         assert test_experiment.id == experiment.id
 
+    def test_get_experiment_not_exists(self: Self) -> None:
+        # arrange
+        non_existant_id = -1
+        client = create_test_client()
+
+        # act
+        resp = client.get(f"/api/v1/experiments/{non_existant_id}")
+
+        # assert
+        assert resp.status_code == 404
+
     def test_get_all_experiments_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"

--- a/src/tests/api/test_experiments.py
+++ b/src/tests/api/test_experiments.py
@@ -1,4 +1,5 @@
 from secrets import token_urlsafe
+from typing import Self
 
 from tests.api.experiment_recipes import create_experiment
 from triangler_fastapi.schemas import ExperimentOutSchema
@@ -6,111 +7,108 @@ from triangler_fastapi.schemas import ExperimentOutSchema
 from .client import create_test_client
 
 
-def test_create_experiment() -> None:
-    # arrange
-    test_name = f"test {token_urlsafe(8)}"
-    client = create_test_client()
+class TestExperimentsApiEndpoints:
+    def test_create_experiment_succeeds(self: Self) -> None:
+        # arrange
+        test_name = f"test {token_urlsafe(8)}"
+        client = create_test_client()
 
-    # act
-    test_experiment = create_experiment(client, name=test_name)
+        # act
+        test_experiment = create_experiment(client, name=test_name)
 
-    # assert
-    assert test_experiment.id is not None
-    assert test_experiment.name == test_name
+        # assert
+        assert test_experiment.id is not None
+        assert test_experiment.name == test_name
 
+    def test_get_experiment_succeeds(self: Self) -> None:
+        # arrange
+        test_name = f"test {token_urlsafe(8)}"
+        client = create_test_client()
+        test_experiment = create_experiment(client, name=test_name)
 
-def test_get_experiment() -> None:
-    # arrange
-    test_name = f"test {token_urlsafe(8)}"
-    client = create_test_client()
-    test_experiment = create_experiment(client, name=test_name)
+        # act
+        resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
+        assert resp.status_code == 200
+        experiment_response_raw = resp.json()
+        experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
 
-    # act
-    resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
-    assert resp.status_code == 200
-    experiment_response_raw = resp.json()
-    experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
+        # assert
+        assert test_experiment.name == experiment.name
+        assert test_experiment.id == experiment.id
 
-    # assert
-    assert test_experiment.name == experiment.name
-    assert test_experiment.id == experiment.id
+    def test_get_all_experiments_succeeds(self: Self) -> None:
+        # arrange
+        test_name = f"test {token_urlsafe(8)}"
+        client = create_test_client()
+        _ = create_experiment(client, name=test_name)
 
+        # act
+        resp = client.get("/api/v1/experiments/")
+        assert resp.status_code == 200
+        all_experiments_raw = resp.json()
+        all_experiments = [
+            ExperimentOutSchema.model_validate(x) for x in all_experiments_raw
+        ]
 
-def test_get_all_experiments() -> None:
-    # arrange
-    test_name = f"test {token_urlsafe(8)}"
-    client = create_test_client()
-    _ = create_experiment(client, name=test_name)
+        # assert
+        assert all_experiments
+        assert test_name in [x.name for x in all_experiments]
 
-    # act
-    resp = client.get("/api/v1/experiments/")
-    assert resp.status_code == 200
-    all_experiments_raw = resp.json()
-    all_experiments = [
-        ExperimentOutSchema.model_validate(x) for x in all_experiments_raw
-    ]
+    def test_update_experiment_succeeds(self: Self) -> None:
+        # arrange
+        test_name = f"test {token_urlsafe(8)}"
+        client = create_test_client()
+        test_experiment = create_experiment(client, name=test_name)
 
-    # assert
-    assert all_experiments
-    assert test_name in [x.name for x in all_experiments]
+        # act
+        resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
+        assert resp.status_code == 200
+        experiment_response_raw = resp.json()
+        experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
 
+        # assert
+        assert test_experiment.name == experiment.name
+        assert test_experiment.id == experiment.id
 
-def test_update_experiment() -> None:
-    # arrange
-    test_name = f"test {token_urlsafe(8)}"
-    client = create_test_client()
-    test_experiment = create_experiment(client, name=test_name)
+        # act
+        test_new_name = f"test {token_urlsafe(8)}"
+        experiment.name = test_new_name
+        updated_experiment_data = experiment.model_dump_json(
+            exclude={"id", "sample_size", "p_value", "created_at", "updated_at"}
+        )
+        resp_update = client.put(
+            f"/api/v1/experiments/{test_experiment.id}", content=updated_experiment_data
+        )
+        assert resp_update.status_code == 200
+        experiment_response_raw = resp.json()
+        resp_updated_get = client.get(f"/api/v1/experiments/{test_experiment.id}")
+        assert resp_updated_get.status_code == 200
+        updated_experiment = ExperimentOutSchema.model_validate(resp_updated_get.json())
 
-    # act
-    resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
-    assert resp.status_code == 200
-    experiment_response_raw = resp.json()
-    experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
+        # assert
+        assert updated_experiment.name == test_new_name
+        assert test_experiment.id == experiment.id
 
-    # assert
-    assert test_experiment.name == experiment.name
-    assert test_experiment.id == experiment.id
+    def test_delete_experiment_succeeds(self: Self) -> None:
+        # arrange
+        test_name = f"test {token_urlsafe(8)}"
+        client = create_test_client()
+        test_experiment = create_experiment(client, name=test_name)
 
-    # act
-    test_new_name = f"test {token_urlsafe(8)}"
-    experiment.name = test_new_name
-    updated_experiment_data = experiment.model_dump_json(
-        exclude={"id", "sample_size", "p_value", "created_at", "updated_at"}
-    )
-    resp_update = client.put(
-        f"/api/v1/experiments/{test_experiment.id}", content=updated_experiment_data
-    )
-    assert resp_update.status_code == 200
-    experiment_response_raw = resp.json()
-    resp_updated_get = client.get(f"/api/v1/experiments/{test_experiment.id}")
-    assert resp_updated_get.status_code == 200
-    updated_experiment = ExperimentOutSchema.model_validate(resp_updated_get.json())
+        # act
+        resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
+        assert resp.status_code == 200
+        experiment_response_raw = resp.json()
+        experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
 
-    # assert
-    assert updated_experiment.name == test_new_name
-    assert test_experiment.id == experiment.id
+        # assert
+        assert test_experiment.name == experiment.name
+        assert test_experiment.id == experiment.id
 
+        # act
+        resp_delete = client.delete(f"/api/v1/experiments/{test_experiment.id}")
+        assert resp_delete.status_code == 200
+        resp_delete_get = client.get(f"/api/v1/experiments/{test_experiment.id}")
 
-def test_delete_experiment() -> None:
-    # arrange
-    test_name = f"test {token_urlsafe(8)}"
-    client = create_test_client()
-    test_experiment = create_experiment(client, name=test_name)
-
-    # act
-    resp = client.get(f"/api/v1/experiments/{test_experiment.id}")
-    assert resp.status_code == 200
-    experiment_response_raw = resp.json()
-    experiment = ExperimentOutSchema.model_validate(experiment_response_raw)
-
-    # assert
-    assert test_experiment.name == experiment.name
-    assert test_experiment.id == experiment.id
-
-    # act
-    resp_delete = client.delete(f"/api/v1/experiments/{test_experiment.id}")
-    assert resp_delete.status_code == 200
-    resp_delete_get = client.get(f"/api/v1/experiments/{test_experiment.id}")
-
-    # assert
-    assert resp_delete_get.status_code == 404
+        # assert
+        assert resp_delete_get.status_code == 404

--- a/src/tests/api/test_experiments.py
+++ b/src/tests/api/test_experiments.py
@@ -155,3 +155,14 @@ class TestExperimentsDeleteApiEndpoints:
 
         # assert
         assert resp_delete_get.status_code == 404
+
+    def test_delete_experiment_fails_not_exists(self: Self) -> None:
+        # arrange
+        non_existant_id = -1
+        client = create_test_client()
+
+        # act
+        resp_delete = client.delete(f"/api/v1/experiments/{non_existant_id}")
+
+        # assert
+        assert resp_delete.status_code == 404

--- a/src/tests/api/test_experiments.py
+++ b/src/tests/api/test_experiments.py
@@ -8,7 +8,7 @@ from triangler_fastapi.schemas import ExperimentOutSchema
 from .client import create_test_client
 
 
-class TestExperimentsApiEndpoints:
+class TestExperimentsCreateApiEndpoints:
     def test_create_experiment_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"
@@ -21,6 +21,8 @@ class TestExperimentsApiEndpoints:
         assert test_experiment.id is not None
         assert test_experiment.name == test_name
 
+
+class TestExperimentsGetApiEndpoints:
     def test_get_experiment_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"
@@ -48,6 +50,8 @@ class TestExperimentsApiEndpoints:
         # assert
         assert resp.status_code == 404
 
+
+class TestExperimentsGetAllApiEndpoints:
     def test_get_all_experiments_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"
@@ -66,6 +70,8 @@ class TestExperimentsApiEndpoints:
         assert all_experiments
         assert test_name in [x.name for x in all_experiments]
 
+
+class TestExperimentsUpdateApiEndpoints:
     def test_update_experiment_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"
@@ -124,6 +130,8 @@ class TestExperimentsApiEndpoints:
         assert "not found" in response_outcome.message
         assert f"{non_existant_id}" in response_outcome.message
 
+
+class TestExperimentsDeleteApiEndpoints:
     def test_delete_experiment_succeeds(self: Self) -> None:
         # arrange
         test_name = f"test {token_urlsafe(8)}"

--- a/src/tests/api/test_experiments.py
+++ b/src/tests/api/test_experiments.py
@@ -2,6 +2,7 @@ from secrets import token_urlsafe
 from typing import Self
 
 from tests.api.experiment_recipes import create_experiment
+from triangler_fastapi.schemas import ActionOutcome
 from triangler_fastapi.schemas import ExperimentOutSchema
 
 from .client import create_test_client
@@ -99,6 +100,29 @@ class TestExperimentsApiEndpoints:
         # assert
         assert updated_experiment.name == test_new_name
         assert test_experiment.id == experiment.id
+
+    def test_update_experiment_fails_not_exists(self: Self) -> None:
+        # arrange
+        non_existant_id = -1
+        client = create_test_client()
+
+        # act
+        updated_experiment_data = {
+            "name": "test",
+            "description": "test",
+            "start_on": "2021-01-01",
+            "end_on": "2021-01-01",
+        }
+        resp_update = client.put(
+            f"/api/v1/experiments/{non_existant_id}", json=updated_experiment_data
+        )
+        assert resp_update.status_code == 200
+        response_outcome = ActionOutcome.model_validate(resp_update.json())
+
+        # assert
+        assert response_outcome.success is False
+        assert "not found" in response_outcome.message
+        assert f"{non_existant_id}" in response_outcome.message
 
     def test_delete_experiment_succeeds(self: Self) -> None:
         # arrange

--- a/src/triangler_fastapi/api/v1/experiment_router.py
+++ b/src/triangler_fastapi/api/v1/experiment_router.py
@@ -82,7 +82,7 @@ def update_experiment(
 @router.delete("/{experiment_id}", status_code=200)
 def delete_experiment(
     experiment_id: int,
-) -> schemas.ActionOutcome | schemas.ActionOutcome:
+) -> schemas.ActionOutcome:
     """Deletes the experiment with a matching id."""
     try:
         usecases.delete_experiment(
@@ -94,12 +94,8 @@ def delete_experiment(
             details={"id": experiment_id},
         )
     except ValueError as e:
-        logger.error(f"Error deleting experiment: {e}")
-        return schemas.ActionOutcome(success=False, message=str(e))
+        logger.error(str(e))
+        raise HTTPException(status_code=404, detail="Experiment not found")
     except Exception as e:
         logger.error(f"Error deleting experiment: {e}")
-        return schemas.ActionOutcome(
-            success=False,
-            message="An error occurred.",
-            details={"error": str(e)},  # TODO: remove this in production
-        )
+        raise HTTPException(status_code=500, detail="Experiment not found")

--- a/src/triangler_fastapi/api/v1/experiment_router.py
+++ b/src/triangler_fastapi/api/v1/experiment_router.py
@@ -51,7 +51,7 @@ def create_experiment(
 @router.put("/{experiment_id}", status_code=200)
 def update_experiment(
     experiment_id: int, payload: schemas.ExperimentInSchema
-) -> schemas.ActionOutcome | schemas.ActionOutcome:
+) -> schemas.ActionOutcome:
     """Updates the experiment with `experiment_id`, using supplied payload"""
     # TODO: should we return the updated experiment?
     try:


### PR DESCRIPTION
This PR updates the experiments CRUD API endpoint tests to:
* align structure with other tests by using test classes
* add tests for getting non existent experiments
* add tests for updating non existent experiments
* update the delete experiment API endpoint to return http response codes on failures
* add tests for deleting non existent experiments